### PR TITLE
feat: support Pool mint

### DIFF
--- a/demo-contract/contracts/wtfswap/Pool.sol
+++ b/demo-contract/contracts/wtfswap/Pool.sol
@@ -1,10 +1,21 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.24;
 
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import "./libraries/SafeCast.sol";
+import "./libraries/SqrtPriceMath.sol";
+import "./libraries/TickMath.sol";
+import "./libraries/LiquidityMath.sol";
+import "./libraries/LowGasSafeMath.sol";
+
 import "./interfaces/IPool.sol";
 import "./interfaces/IFactory.sol";
 
 contract Pool is IPool {
+    using SafeCast for int256;
+    using LowGasSafeMath for uint256;
+
     /// @inheritdoc IPool
     address public immutable override factory;
     /// @inheritdoc IPool
@@ -43,19 +54,93 @@ contract Pool is IPool {
         sqrtPriceX96 = sqrtPriceX96_;
     }
 
+    struct ModifyPositionParams {
+        // the address that owns the position
+        address owner;
+        // any change in liquidity
+        int128 liquidityDelta;
+    }
+
+    function _modifyPosition(
+        ModifyPositionParams memory params
+    ) private returns (int256 amount0, int256 amount1) {
+        // 通过新增的流动性计算 amount0 和 amount1
+        // 参考 UniswapV3 的代码
+        amount0 = SqrtPriceMath.getAmount0Delta(
+            sqrtPriceX96,
+            TickMath.getSqrtRatioAtTick(tickUpper),
+            params.liquidityDelta
+        );
+        amount1 = SqrtPriceMath.getAmount1Delta(
+            TickMath.getSqrtRatioAtTick(tickLower),
+            sqrtPriceX96,
+            params.liquidityDelta
+        );
+
+        // 修改 liquidity
+        uint128 liquidityBefore = liquidity;
+        liquidity = LiquidityMath.addDelta(
+            liquidityBefore,
+            params.liquidityDelta
+        );
+    }
+
+    /// @dev Get the pool's balance of token0
+    /// @dev This function is gas optimized to avoid a redundant extcodesize check in addition to the returndatasize
+    /// check
+    function balance0() private view returns (uint256) {
+        (bool success, bytes memory data) = token0.staticcall(
+            abi.encodeWithSelector(IERC20.balanceOf.selector, address(this))
+        );
+        require(success && data.length >= 32);
+        return abi.decode(data, (uint256));
+    }
+
+    /// @dev Get the pool's balance of token1
+    /// @dev This function is gas optimized to avoid a redundant extcodesize check in addition to the returndatasize
+    /// check
+    function balance1() private view returns (uint256) {
+        (bool success, bytes memory data) = token1.staticcall(
+            abi.encodeWithSelector(IERC20.balanceOf.selector, address(this))
+        );
+        require(success && data.length >= 32);
+        return abi.decode(data, (uint256));
+    }
+
     function mint(
         address recipient,
         uint128 amount,
         bytes calldata data
     ) external override returns (uint256 amount0, uint256 amount1) {
+        require(amount > 0, "Mint amount must be greater than 0");
         // 基于 amount 计算出当前需要多少 amount0 和 amount1
-        // TODO 当前先写个假的
-        (amount0, amount1) = (amount / 2, amount / 2);
+        (int256 amount0Int, int256 amount1Int) = _modifyPosition(
+            ModifyPositionParams({
+                owner: recipient,
+                liquidityDelta: int256(int128(amount)).toInt128()
+            })
+        );
+        amount0 = uint256(amount0Int);
+        amount1 = uint256(amount1Int);
         // 把流动性记录到对应的 position 中
         positions[recipient].liquidity += amount;
+        // 记录用户的 tokenOwed0 和 tokenOwed1
+        positions[recipient].tokensOwed0 += amount0;
+        positions[recipient].tokensOwed1 += amount1;
+
+        uint256 balance0Before;
+        uint256 balance1Before;
+        if (amount0 > 0) balance0Before = balance0();
+        if (amount1 > 0) balance1Before = balance1();
         // 回调 mintCallback
         IMintCallback(recipient).mintCallback(amount0, amount1, data);
-        // TODO 检查钱到位了没有，如果到位了对应修改相关信息
+
+        if (amount0 > 0)
+            require(balance0Before.add(amount0) <= balance0(), "M0");
+        if (amount1 > 0)
+            require(balance1Before.add(amount1) <= balance1(), "M1");
+
+        emit Mint(msg.sender, recipient, amount, amount0, amount1);
     }
 
     function collect(

--- a/demo-contract/contracts/wtfswap/Pool.sol
+++ b/demo-contract/contracts/wtfswap/Pool.sol
@@ -124,9 +124,6 @@ contract Pool is IPool {
         amount1 = uint256(amount1Int);
         // 把流动性记录到对应的 position 中
         positions[recipient].liquidity += amount;
-        // 记录用户的 tokenOwed0 和 tokenOwed1
-        positions[recipient].tokensOwed0 += amount0;
-        positions[recipient].tokensOwed1 += amount1;
 
         uint256 balance0Before;
         uint256 balance1Before;

--- a/demo-contract/contracts/wtfswap/libraries/FixedPoint96.sol
+++ b/demo-contract/contracts/wtfswap/libraries/FixedPoint96.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.4.0;
+
+/// @title FixedPoint96
+/// @notice A library for handling binary fixed point numbers, see https://en.wikipedia.org/wiki/Q_(number_format)
+/// @dev Used in SqrtPriceMath.sol
+library FixedPoint96 {
+    uint8 internal constant RESOLUTION = 96;
+    uint256 internal constant Q96 = 0x1000000000000000000000000;
+}

--- a/demo-contract/contracts/wtfswap/libraries/FullMath.sol
+++ b/demo-contract/contracts/wtfswap/libraries/FullMath.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.0;
+
+/// @title Contains 512-bit math functions
+/// @notice Facilitates multiplication and division that can have overflow of an intermediate value without any loss of precision
+/// @dev Handles "phantom overflow" i.e., allows multiplication and division where an intermediate value overflows 256 bits
+library FullMath {
+    /// @notice Calculates floor(a×b÷denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
+    /// @param a The multiplicand
+    /// @param b The multiplier
+    /// @param denominator The divisor
+    /// @return result The 256-bit result
+    /// @dev Credit to Remco Bloemen under MIT license https://xn--2-umb.com/21/muldiv
+    function mulDiv(
+        uint256 a,
+        uint256 b,
+        uint256 denominator
+    ) internal pure returns (uint256 result) {
+        // 512-bit multiply [prod1 prod0] = a * b
+        // Compute the product mod 2**256 and mod 2**256 - 1
+        // then use the Chinese Remainder Theorem to reconstruct
+        // the 512 bit result. The result is stored in two 256
+        // variables such that product = prod1 * 2**256 + prod0
+        uint256 prod0; // Least significant 256 bits of the product
+        uint256 prod1; // Most significant 256 bits of the product
+        assembly {
+            let mm := mulmod(a, b, not(0))
+            prod0 := mul(a, b)
+            prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+        }
+
+        // Handle non-overflow cases, 256 by 256 division
+        if (prod1 == 0) {
+            require(denominator > 0);
+            assembly {
+                result := div(prod0, denominator)
+            }
+            return result;
+        }
+
+        // Make sure the result is less than 2**256.
+        // Also prevents denominator == 0
+        require(denominator > prod1);
+
+        ///////////////////////////////////////////////
+        // 512 by 256 division.
+        ///////////////////////////////////////////////
+
+        // Make division exact by subtracting the remainder from [prod1 prod0]
+        // Compute remainder using mulmod
+        uint256 remainder;
+        assembly {
+            remainder := mulmod(a, b, denominator)
+        }
+        // Subtract 256 bit number from 512 bit number
+        assembly {
+            prod1 := sub(prod1, gt(remainder, prod0))
+            prod0 := sub(prod0, remainder)
+        }
+
+        // Factor powers of two out of denominator
+        // Compute largest power of two divisor of denominator.
+        // Always >= 1.
+        uint256 twos = denominator ^ (denominator - 1);
+        // Divide denominator by power of two
+        assembly {
+            denominator := div(denominator, twos)
+        }
+
+        // Divide [prod1 prod0] by the factors of two
+        assembly {
+            prod0 := div(prod0, twos)
+        }
+        // Shift in bits from prod1 into prod0. For this we need
+        // to flip `twos` such that it is 2**256 / twos.
+        // If twos is zero, then it becomes one
+        assembly {
+            twos := add(div(sub(0, twos), twos), 1)
+        }
+        prod0 |= prod1 * twos;
+
+        // Invert denominator mod 2**256
+        // Now that denominator is an odd number, it has an inverse
+        // modulo 2**256 such that denominator * inv = 1 mod 2**256.
+        // Compute the inverse by starting with a seed that is correct
+        // correct for four bits. That is, denominator * inv = 1 mod 2**4
+        uint256 inv = (3 * denominator) ^ 2;
+        // Now use Newton-Raphson iteration to improve the precision.
+        // Thanks to Hensel's lifting lemma, this also works in modular
+        // arithmetic, doubling the correct bits in each step.
+        inv *= 2 - denominator * inv; // inverse mod 2**8
+        inv *= 2 - denominator * inv; // inverse mod 2**16
+        inv *= 2 - denominator * inv; // inverse mod 2**32
+        inv *= 2 - denominator * inv; // inverse mod 2**64
+        inv *= 2 - denominator * inv; // inverse mod 2**128
+        inv *= 2 - denominator * inv; // inverse mod 2**256
+
+        // Because the division is now exact we can divide by multiplying
+        // with the modular inverse of denominator. This will give us the
+        // correct result modulo 2**256. Since the precoditions guarantee
+        // that the outcome is less than 2**256, this is the final result.
+        // We don't need to compute the high bits of the result and prod1
+        // is no longer required.
+        result = prod0 * inv;
+        return result;
+    }
+
+    /// @notice Calculates ceil(a×b÷denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
+    /// @param a The multiplicand
+    /// @param b The multiplier
+    /// @param denominator The divisor
+    /// @return result The 256-bit result
+    function mulDivRoundingUp(
+        uint256 a,
+        uint256 b,
+        uint256 denominator
+    ) internal pure returns (uint256 result) {
+        result = mulDiv(a, b, denominator);
+        if (mulmod(a, b, denominator) > 0) {
+            require(result < type(uint256).max);
+            result++;
+        }
+    }
+}

--- a/demo-contract/contracts/wtfswap/libraries/LiquidityMath.sol
+++ b/demo-contract/contracts/wtfswap/libraries/LiquidityMath.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Math library for liquidity
+library LiquidityMath {
+    /// @notice Add a signed liquidity delta to liquidity and revert if it overflows or underflows
+    /// @param x The liquidity before change
+    /// @param y The delta by which liquidity should be changed
+    /// @return z The liquidity delta
+    function addDelta(uint128 x, int128 y) internal pure returns (uint128 z) {
+        if (y < 0) {
+            require((z = x - uint128(-y)) < x, 'LS');
+        } else {
+            require((z = x + uint128(y)) >= x, 'LA');
+        }
+    }
+}

--- a/demo-contract/contracts/wtfswap/libraries/LowGasSafeMath.sol
+++ b/demo-contract/contracts/wtfswap/libraries/LowGasSafeMath.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.0;
+
+/// @title Optimized overflow and underflow safe math operations
+/// @notice Contains methods for doing math operations that revert on overflow or underflow for minimal gas cost
+library LowGasSafeMath {
+    /// @notice Returns x + y, reverts if sum overflows uint256
+    /// @param x The augend
+    /// @param y The addend
+    /// @return z The sum of x and y
+    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x + y) >= x);
+    }
+
+    /// @notice Returns x - y, reverts if underflows
+    /// @param x The minuend
+    /// @param y The subtrahend
+    /// @return z The difference of x and y
+    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x - y) <= x);
+    }
+
+    /// @notice Returns x * y, reverts if overflows
+    /// @param x The multiplicand
+    /// @param y The multiplier
+    /// @return z The product of x and y
+    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require(x == 0 || (z = x * y) / x == y);
+    }
+
+    /// @notice Returns x + y, reverts if overflows or underflows
+    /// @param x The augend
+    /// @param y The addend
+    /// @return z The sum of x and y
+    function add(int256 x, int256 y) internal pure returns (int256 z) {
+        require((z = x + y) >= x == (y >= 0));
+    }
+
+    /// @notice Returns x - y, reverts if overflows or underflows
+    /// @param x The minuend
+    /// @param y The subtrahend
+    /// @return z The difference of x and y
+    function sub(int256 x, int256 y) internal pure returns (int256 z) {
+        require((z = x - y) <= x == (y >= 0));
+    }
+}

--- a/demo-contract/contracts/wtfswap/libraries/SafeCast.sol
+++ b/demo-contract/contracts/wtfswap/libraries/SafeCast.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Safe casting methods
+/// @notice Contains methods for safely casting between types
+library SafeCast {
+    /// @notice Cast a uint256 to a uint160, revert on overflow
+    /// @param y The uint256 to be downcasted
+    /// @return z The downcasted integer, now type uint160
+    function toUint160(uint256 y) internal pure returns (uint160 z) {
+        require((z = uint160(y)) == y);
+    }
+
+    /// @notice Cast a int256 to a int128, revert on overflow or underflow
+    /// @param y The int256 to be downcasted
+    /// @return z The downcasted integer, now type int128
+    function toInt128(int256 y) internal pure returns (int128 z) {
+        require((z = int128(y)) == y);
+    }
+
+    /// @notice Cast a uint256 to a int256, revert on overflow
+    /// @param y The uint256 to be casted
+    /// @return z The casted integer, now type int256
+    function toInt256(uint256 y) internal pure returns (int256 z) {
+        require(y < 2 ** 255);
+        z = int256(y);
+    }
+}

--- a/demo-contract/contracts/wtfswap/libraries/SqrtPriceMath.sol
+++ b/demo-contract/contracts/wtfswap/libraries/SqrtPriceMath.sol
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import "./LowGasSafeMath.sol";
+import "./SafeCast.sol";
+
+import "./FullMath.sol";
+import "./UnsafeMath.sol";
+import "./FixedPoint96.sol";
+
+/// @title Functions based on Q64.96 sqrt price and liquidity
+/// @notice Contains the math that uses square root of price as a Q64.96 and liquidity to compute deltas
+library SqrtPriceMath {
+    using LowGasSafeMath for uint256;
+    using SafeCast for uint256;
+
+    /// @notice Gets the next sqrt price given a delta of token0
+    /// @dev Always rounds up, because in the exact output case (increasing price) we need to move the price at least
+    /// far enough to get the desired output amount, and in the exact input case (decreasing price) we need to move the
+    /// price less in order to not send too much output.
+    /// The most precise formula for this is liquidity * sqrtPX96 / (liquidity +- amount * sqrtPX96),
+    /// if this is impossible because of overflow, we calculate liquidity / (liquidity / sqrtPX96 +- amount).
+    /// @param sqrtPX96 The starting price, i.e. before accounting for the token0 delta
+    /// @param liquidity The amount of usable liquidity
+    /// @param amount How much of token0 to add or remove from virtual reserves
+    /// @param add Whether to add or remove the amount of token0
+    /// @return The price after adding or removing amount, depending on add
+    function getNextSqrtPriceFromAmount0RoundingUp(
+        uint160 sqrtPX96,
+        uint128 liquidity,
+        uint256 amount,
+        bool add
+    ) internal pure returns (uint160) {
+        // we short circuit amount == 0 because the result is otherwise not guaranteed to equal the input price
+        if (amount == 0) return sqrtPX96;
+        uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
+
+        if (add) {
+            uint256 product;
+            if ((product = amount * sqrtPX96) / amount == sqrtPX96) {
+                uint256 denominator = numerator1 + product;
+                if (denominator >= numerator1)
+                    // always fits in 160 bits
+                    return
+                        uint160(
+                            FullMath.mulDivRoundingUp(
+                                numerator1,
+                                sqrtPX96,
+                                denominator
+                            )
+                        );
+            }
+
+            return
+                uint160(
+                    UnsafeMath.divRoundingUp(
+                        numerator1,
+                        (numerator1 / sqrtPX96).add(amount)
+                    )
+                );
+        } else {
+            uint256 product;
+            // if the product overflows, we know the denominator underflows
+            // in addition, we must check that the denominator does not underflow
+            require(
+                (product = amount * sqrtPX96) / amount == sqrtPX96 &&
+                    numerator1 > product
+            );
+            uint256 denominator = numerator1 - product;
+            return
+                FullMath
+                    .mulDivRoundingUp(numerator1, sqrtPX96, denominator)
+                    .toUint160();
+        }
+    }
+
+    /// @notice Gets the next sqrt price given a delta of token1
+    /// @dev Always rounds down, because in the exact output case (decreasing price) we need to move the price at least
+    /// far enough to get the desired output amount, and in the exact input case (increasing price) we need to move the
+    /// price less in order to not send too much output.
+    /// The formula we compute is within <1 wei of the lossless version: sqrtPX96 +- amount / liquidity
+    /// @param sqrtPX96 The starting price, i.e., before accounting for the token1 delta
+    /// @param liquidity The amount of usable liquidity
+    /// @param amount How much of token1 to add, or remove, from virtual reserves
+    /// @param add Whether to add, or remove, the amount of token1
+    /// @return The price after adding or removing `amount`
+    function getNextSqrtPriceFromAmount1RoundingDown(
+        uint160 sqrtPX96,
+        uint128 liquidity,
+        uint256 amount,
+        bool add
+    ) internal pure returns (uint160) {
+        // if we're adding (subtracting), rounding down requires rounding the quotient down (up)
+        // in both cases, avoid a mulDiv for most inputs
+        if (add) {
+            uint256 quotient = (
+                amount <= type(uint160).max
+                    ? (amount << FixedPoint96.RESOLUTION) / liquidity
+                    : FullMath.mulDiv(amount, FixedPoint96.Q96, liquidity)
+            );
+
+            return uint256(sqrtPX96).add(quotient).toUint160();
+        } else {
+            uint256 quotient = (
+                amount <= type(uint160).max
+                    ? UnsafeMath.divRoundingUp(
+                        amount << FixedPoint96.RESOLUTION,
+                        liquidity
+                    )
+                    : FullMath.mulDivRoundingUp(
+                        amount,
+                        FixedPoint96.Q96,
+                        liquidity
+                    )
+            );
+
+            require(sqrtPX96 > quotient);
+            // always fits 160 bits
+            return uint160(sqrtPX96 - quotient);
+        }
+    }
+
+    /// @notice Gets the next sqrt price given an input amount of token0 or token1
+    /// @dev Throws if price or liquidity are 0, or if the next price is out of bounds
+    /// @param sqrtPX96 The starting price, i.e., before accounting for the input amount
+    /// @param liquidity The amount of usable liquidity
+    /// @param amountIn How much of token0, or token1, is being swapped in
+    /// @param zeroForOne Whether the amount in is token0 or token1
+    /// @return sqrtQX96 The price after adding the input amount to token0 or token1
+    function getNextSqrtPriceFromInput(
+        uint160 sqrtPX96,
+        uint128 liquidity,
+        uint256 amountIn,
+        bool zeroForOne
+    ) internal pure returns (uint160 sqrtQX96) {
+        require(sqrtPX96 > 0);
+        require(liquidity > 0);
+
+        // round to make sure that we don't pass the target price
+        return
+            zeroForOne
+                ? getNextSqrtPriceFromAmount0RoundingUp(
+                    sqrtPX96,
+                    liquidity,
+                    amountIn,
+                    true
+                )
+                : getNextSqrtPriceFromAmount1RoundingDown(
+                    sqrtPX96,
+                    liquidity,
+                    amountIn,
+                    true
+                );
+    }
+
+    /// @notice Gets the next sqrt price given an output amount of token0 or token1
+    /// @dev Throws if price or liquidity are 0 or the next price is out of bounds
+    /// @param sqrtPX96 The starting price before accounting for the output amount
+    /// @param liquidity The amount of usable liquidity
+    /// @param amountOut How much of token0, or token1, is being swapped out
+    /// @param zeroForOne Whether the amount out is token0 or token1
+    /// @return sqrtQX96 The price after removing the output amount of token0 or token1
+    function getNextSqrtPriceFromOutput(
+        uint160 sqrtPX96,
+        uint128 liquidity,
+        uint256 amountOut,
+        bool zeroForOne
+    ) internal pure returns (uint160 sqrtQX96) {
+        require(sqrtPX96 > 0);
+        require(liquidity > 0);
+
+        // round to make sure that we pass the target price
+        return
+            zeroForOne
+                ? getNextSqrtPriceFromAmount1RoundingDown(
+                    sqrtPX96,
+                    liquidity,
+                    amountOut,
+                    false
+                )
+                : getNextSqrtPriceFromAmount0RoundingUp(
+                    sqrtPX96,
+                    liquidity,
+                    amountOut,
+                    false
+                );
+    }
+
+    /// @notice Gets the amount0 delta between two prices
+    /// @dev Calculates liquidity / sqrt(lower) - liquidity / sqrt(upper),
+    /// i.e. liquidity * (sqrt(upper) - sqrt(lower)) / (sqrt(upper) * sqrt(lower))
+    /// @param sqrtRatioAX96 A sqrt price
+    /// @param sqrtRatioBX96 Another sqrt price
+    /// @param liquidity The amount of usable liquidity
+    /// @param roundUp Whether to round the amount up or down
+    /// @return amount0 Amount of token0 required to cover a position of size liquidity between the two passed prices
+    function getAmount0Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity,
+        bool roundUp
+    ) internal pure returns (uint256 amount0) {
+        if (sqrtRatioAX96 > sqrtRatioBX96)
+            (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+        uint256 numerator1 = uint256(liquidity) << FixedPoint96.RESOLUTION;
+        uint256 numerator2 = sqrtRatioBX96 - sqrtRatioAX96;
+
+        require(sqrtRatioAX96 > 0);
+
+        return
+            roundUp
+                ? UnsafeMath.divRoundingUp(
+                    FullMath.mulDivRoundingUp(
+                        numerator1,
+                        numerator2,
+                        sqrtRatioBX96
+                    ),
+                    sqrtRatioAX96
+                )
+                : FullMath.mulDiv(numerator1, numerator2, sqrtRatioBX96) /
+                    sqrtRatioAX96;
+    }
+
+    /// @notice Gets the amount1 delta between two prices
+    /// @dev Calculates liquidity * (sqrt(upper) - sqrt(lower))
+    /// @param sqrtRatioAX96 A sqrt price
+    /// @param sqrtRatioBX96 Another sqrt price
+    /// @param liquidity The amount of usable liquidity
+    /// @param roundUp Whether to round the amount up, or down
+    /// @return amount1 Amount of token1 required to cover a position of size liquidity between the two passed prices
+    function getAmount1Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        uint128 liquidity,
+        bool roundUp
+    ) internal pure returns (uint256 amount1) {
+        if (sqrtRatioAX96 > sqrtRatioBX96)
+            (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
+
+        return
+            roundUp
+                ? FullMath.mulDivRoundingUp(
+                    liquidity,
+                    sqrtRatioBX96 - sqrtRatioAX96,
+                    FixedPoint96.Q96
+                )
+                : FullMath.mulDiv(
+                    liquidity,
+                    sqrtRatioBX96 - sqrtRatioAX96,
+                    FixedPoint96.Q96
+                );
+    }
+
+    /// @notice Helper that gets signed token0 delta
+    /// @param sqrtRatioAX96 A sqrt price
+    /// @param sqrtRatioBX96 Another sqrt price
+    /// @param liquidity The change in liquidity for which to compute the amount0 delta
+    /// @return amount0 Amount of token0 corresponding to the passed liquidityDelta between the two prices
+    function getAmount0Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        int128 liquidity
+    ) internal pure returns (int256 amount0) {
+        return
+            liquidity < 0
+                ? -getAmount0Delta(
+                    sqrtRatioAX96,
+                    sqrtRatioBX96,
+                    uint128(-liquidity),
+                    false
+                ).toInt256()
+                : getAmount0Delta(
+                    sqrtRatioAX96,
+                    sqrtRatioBX96,
+                    uint128(liquidity),
+                    true
+                ).toInt256();
+    }
+
+    /// @notice Helper that gets signed token1 delta
+    /// @param sqrtRatioAX96 A sqrt price
+    /// @param sqrtRatioBX96 Another sqrt price
+    /// @param liquidity The change in liquidity for which to compute the amount1 delta
+    /// @return amount1 Amount of token1 corresponding to the passed liquidityDelta between the two prices
+    function getAmount1Delta(
+        uint160 sqrtRatioAX96,
+        uint160 sqrtRatioBX96,
+        int128 liquidity
+    ) internal pure returns (int256 amount1) {
+        return
+            liquidity < 0
+                ? -getAmount1Delta(
+                    sqrtRatioAX96,
+                    sqrtRatioBX96,
+                    uint128(-liquidity),
+                    false
+                ).toInt256()
+                : getAmount1Delta(
+                    sqrtRatioAX96,
+                    sqrtRatioBX96,
+                    uint128(liquidity),
+                    true
+                ).toInt256();
+    }
+}

--- a/demo-contract/contracts/wtfswap/libraries/TickMath.sol
+++ b/demo-contract/contracts/wtfswap/libraries/TickMath.sol
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Math library for computing sqrt prices from ticks and vice versa
+/// @notice Computes sqrt price for ticks of size 1.0001, i.e. sqrt(1.0001^tick) as fixed point Q64.96 numbers. Supports
+/// prices between 2**-128 and 2**128
+library TickMath {
+    /// @dev The minimum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**-128
+    int24 internal constant MIN_TICK = -887272;
+    /// @dev The maximum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**128
+    int24 internal constant MAX_TICK = -MIN_TICK;
+
+    /// @dev The minimum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MIN_TICK)
+    uint160 internal constant MIN_SQRT_RATIO = 4295128739;
+    /// @dev The maximum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MAX_TICK)
+    uint160 internal constant MAX_SQRT_RATIO =
+        1461446703485210103287273052203988822378723970342;
+
+    /// @notice Calculates sqrt(1.0001^tick) * 2^96
+    /// @dev Throws if |tick| > max tick
+    /// @param tick The input tick for the above formula
+    /// @return sqrtPriceX96 A Fixed point Q64.96 number representing the sqrt of the ratio of the two assets (token1/token0)
+    /// at the given tick
+    function getSqrtRatioAtTick(
+        int24 tick
+    ) internal pure returns (uint160 sqrtPriceX96) {
+        uint256 absTick = tick < 0
+            ? uint256(-int256(tick))
+            : uint256(int256(tick));
+        require(absTick <= uint256(int256(MAX_TICK)), "T");
+
+        uint256 ratio = absTick & 0x1 != 0
+            ? 0xfffcb933bd6fad37aa2d162d1a594001
+            : 0x100000000000000000000000000000000;
+        if (absTick & 0x2 != 0)
+            ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;
+        if (absTick & 0x4 != 0)
+            ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128;
+        if (absTick & 0x8 != 0)
+            ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128;
+        if (absTick & 0x10 != 0)
+            ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644) >> 128;
+        if (absTick & 0x20 != 0)
+            ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0) >> 128;
+        if (absTick & 0x40 != 0)
+            ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861) >> 128;
+        if (absTick & 0x80 != 0)
+            ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053) >> 128;
+        if (absTick & 0x100 != 0)
+            ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4) >> 128;
+        if (absTick & 0x200 != 0)
+            ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54) >> 128;
+        if (absTick & 0x400 != 0)
+            ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3) >> 128;
+        if (absTick & 0x800 != 0)
+            ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9) >> 128;
+        if (absTick & 0x1000 != 0)
+            ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825) >> 128;
+        if (absTick & 0x2000 != 0)
+            ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5) >> 128;
+        if (absTick & 0x4000 != 0)
+            ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7) >> 128;
+        if (absTick & 0x8000 != 0)
+            ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6) >> 128;
+        if (absTick & 0x10000 != 0)
+            ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9) >> 128;
+        if (absTick & 0x20000 != 0)
+            ratio = (ratio * 0x5d6af8dedb81196699c329225ee604) >> 128;
+        if (absTick & 0x40000 != 0)
+            ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98) >> 128;
+        if (absTick & 0x80000 != 0)
+            ratio = (ratio * 0x48a170391f7dc42444e8fa2) >> 128;
+
+        if (tick > 0) ratio = type(uint256).max / ratio;
+
+        // this divides by 1<<32 rounding up to go from a Q128.128 to a Q128.96.
+        // we then downcast because we know the result always fits within 160 bits due to our tick input constraint
+        // we round up in the division so getTickAtSqrtRatio of the output price is always consistent
+        sqrtPriceX96 = uint160(
+            (ratio >> 32) + (ratio % (1 << 32) == 0 ? 0 : 1)
+        );
+    }
+
+    /// @notice Calculates the greatest tick value such that getRatioAtTick(tick) <= ratio
+    /// @dev Throws in case sqrtPriceX96 < MIN_SQRT_RATIO, as MIN_SQRT_RATIO is the lowest value getRatioAtTick may
+    /// ever return.
+    /// @param sqrtPriceX96 The sqrt ratio for which to compute the tick as a Q64.96
+    /// @return tick The greatest tick for which the ratio is less than or equal to the input ratio
+    function getTickAtSqrtRatio(
+        uint160 sqrtPriceX96
+    ) internal pure returns (int24 tick) {
+        // second inequality must be < because the price can never reach the price at the max tick
+        require(
+            sqrtPriceX96 >= MIN_SQRT_RATIO && sqrtPriceX96 < MAX_SQRT_RATIO,
+            "R"
+        );
+        uint256 ratio = uint256(sqrtPriceX96) << 32;
+
+        uint256 r = ratio;
+        uint256 msb = 0;
+
+        assembly {
+            let f := shl(7, gt(r, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(6, gt(r, 0xFFFFFFFFFFFFFFFF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(5, gt(r, 0xFFFFFFFF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(4, gt(r, 0xFFFF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(3, gt(r, 0xFF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(2, gt(r, 0xF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(1, gt(r, 0x3))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := gt(r, 0x1)
+            msb := or(msb, f)
+        }
+
+        if (msb >= 128) r = ratio >> (msb - 127);
+        else r = ratio << (127 - msb);
+
+        int256 log_2 = (int256(msb) - 128) << 64;
+
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(63, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(62, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(61, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(60, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(59, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(58, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(57, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(56, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(55, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(54, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(53, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(52, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(51, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(50, f))
+        }
+
+        int256 log_sqrt10001 = log_2 * 255738958999603826347141; // 128.128 number
+
+        int24 tickLow = int24(
+            (log_sqrt10001 - 3402992956809132418596140100660247210) >> 128
+        );
+        int24 tickHi = int24(
+            (log_sqrt10001 + 291339464771989622907027621153398088495) >> 128
+        );
+
+        tick = tickLow == tickHi
+            ? tickLow
+            : getSqrtRatioAtTick(tickHi) <= sqrtPriceX96
+            ? tickHi
+            : tickLow;
+    }
+}

--- a/demo-contract/contracts/wtfswap/libraries/UnsafeMath.sol
+++ b/demo-contract/contracts/wtfswap/libraries/UnsafeMath.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Math functions that do not check inputs or outputs
+/// @notice Contains methods that perform common math functions but do not do any overflow or underflow checks
+library UnsafeMath {
+    /// @notice Returns ceil(x / y)
+    /// @dev division by 0 has unspecified behavior, and must be checked externally
+    /// @param x The dividend
+    /// @param y The divisor
+    /// @return z The quotient, ceil(x / y)
+    function divRoundingUp(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        assembly {
+            z := add(div(x, y), gt(mod(x, y), 0))
+        }
+    }
+}


### PR DESCRIPTION
支持了 LP 的 mint 方法，主要参考了 Uniswap V3 的代码 https://github.com/Uniswap/v3-core/blob/main/contracts/UniswapV3Pool.sol#L457

相比 Uniswap V3 简单了很多，每个 Pool 限定在一个价格上下限内，按照要注入的流动性把对应 token0 和 token1 的数量计算出来就行。

引入到 Uniswap V3 中的一些 library，大部分都是 copy 过来的，只有两个点做了修改：
- `FullMath.sol` 的 `uint256 twos = -denominator & denominator;` 修改为 `uint256 twos = denominator ^ (denominator - 1);`
- `TickMath.sol` 的 `require(absTick <= uint256(MAX_TICK), 'T');` 修改为 `require(absTick <= uint256(int256(MAX_TICK)), "T");`
- 上面两个文件的 `solidity <0.8.0` 的限制去掉了（应该也是导致上面两个地方报错需要修改的原因）。0.8 版本的 solidity 在一些运算上和 0.7 有一些差异。

balance0 和 balance1 也是参考了 Uniswap V3 的代码，只是把 `IERC20Minimal` 换成了 `IERC20`。