### PR TITLE
SwapRouter 合约

### DIFF
--- a/P109_SwapRouter/readme.md
+++ b/P109_SwapRouter/readme.md
@@ -1,0 +1,7 @@
+本节作者：[@mocha.wiz](https://x.com/mocha_wizard) [@愚指导](https://x.com/yudao1024)
+
+这一讲我们将引导大家完成 `SwapRouter.sol` 合约的开发。
+
+---
+
+TODO

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 
 **第 P108 讲：PositionManager 合约开发**：[教程](./P108_PositionManager/readme.md) | [代码](./demo-contract/contracts/wtfswap/PositionManager.sol)
 
-**第 P109 讲：SwapRouter 合约开发**
+**第 P109 讲：SwapRouter 合约开发**：[教程](./P109_SwapRouter/readme.md) | [代码](./demo-contract/contracts/wtfswap/SwapRouter.sol)
 
 **第 P201 讲：初始化前端代码和技术分析**：[教程](./P201_InitFrontend/readme.md) | [代码](./P201_InitFrontend/code/)
 

--- a/demo-contract/contracts/wtfswap/Factory.sol
+++ b/demo-contract/contracts/wtfswap/Factory.sol
@@ -30,7 +30,7 @@ contract Factory is IFactory {
 
         (token0, token1) = sortToken(tokenA, tokenB);
 
-        return pools[tokenA][tokenB][index];
+        return pools[token0][token1][index];
     }
 
     function createPool(

--- a/demo-contract/contracts/wtfswap/SwapRouter.sol
+++ b/demo-contract/contracts/wtfswap/SwapRouter.sol
@@ -17,63 +17,137 @@ contract SwapRouter is ISwapRouter {
     function exactInput(
         ExactInputParams calldata params
     ) external payable override returns (uint256 amountOut) {
-        // 用 index 记录当前正在读取的 index
-        uint256 index = 0;
-        // while 循环遍历 indexPath，获取每个 pool 的价格
-        while (index < params.indexPath.length) {
+        uint256 amountIn = params.amountIn;
+
+        for (uint256 i = 0; i < params.indexPath.length; i++) {
             address _pool = poolManager.getPool(
                 params.tokenIn,
                 params.tokenOut,
-                params.indexPath[index]
+                params.indexPath[i]
             );
             IPool pool = IPool(_pool);
-            // TODO 交易
-            bytes memory data;
-            // 交易的钱统一转给本合约，最后都完成之后在 swapCallback 中打给用户
-            pool.swap(msg.sender, true, 12, 12, data);
-            amountOut += 2;
-            index++;
+
+            (uint256 amount0Out, uint256 amount1Out) = pool.getAmountsOut(
+                amountIn
+            );
+            amountOut = params.tokenIn < params.tokenOut
+                ? amount1Out
+                : amount0Out;
+
+            bytes memory data = abi.encode(
+                msg.sender,
+                params.tokenIn,
+                params.tokenOut
+            );
+            pool.swap(
+                msg.sender,
+                params.tokenIn < params.tokenOut,
+                amountIn,
+                amountOut,
+                data
+            );
+
+            amountIn = amountOut; // 为下一次循环准备
         }
     }
 
     // 确定输出的 token 交易
     function exactOutput(
         ExactOutputParams calldata params
-    ) external payable override returns (uint256 amountIn) {}
+    ) external payable override returns (uint256 amountIn) {
+        uint256 amountOut = params.amountOut;
+
+        for (uint256 i = params.indexPath.length; i > 0; i--) {
+            address _pool = poolManager.getPool(
+                params.tokenIn,
+                params.tokenOut,
+                params.indexPath[i - 1]
+            );
+            IPool pool = IPool(_pool);
+
+            (uint256 amount0In, uint256 amount1In) = pool.getAmountsIn(
+                amountOut
+            );
+            amountIn = params.tokenIn < params.tokenOut ? amount0In : amount1In;
+
+            bytes memory data = abi.encode(
+                msg.sender,
+                params.tokenIn,
+                params.tokenOut
+            );
+            pool.swap(
+                msg.sender,
+                params.tokenIn > params.tokenOut,
+                amountIn,
+                amountOut,
+                data
+            );
+
+            amountOut = amountIn; // 为下一次循环准备
+        }
+    }
 
     // 确认输入的 token，估算可以获得多少输出的 token
     function quoteExactInput(
         QuoteExactInputParams memory params
     ) external view override returns (uint256 amountOut) {
-        // 用 index 记录当前正在读取的 index
-        uint256 index = 0;
-        // while 循环遍历 indexPath，获取每个 pool 的价格
-        while (index < params.indexPath.length) {
+        uint256 amountIn = params.amountIn;
+
+        for (uint256 i = 0; i < params.indexPath.length; i++) {
             address _pool = poolManager.getPool(
                 params.tokenIn,
                 params.tokenOut,
-                params.indexPath[index]
+                params.indexPath[i]
             );
             IPool pool = IPool(_pool);
-            uint160 sqrtPriceX96 = pool.sqrtPriceX96();
-            // TODO 计算 amountOut
-            amountOut = sqrtPriceX96;
-            // 更新 index
-            index++;
+
+            (uint256 amount0Out, uint256 amount1Out) = pool.getAmountsOut(
+                amountIn
+            );
+            amountOut = params.tokenIn < params.tokenOut
+                ? amount1Out
+                : amount0Out;
+
+            amountIn = amountOut; // 为下一次循环准备
         }
     }
 
     // 确认输出的 token，估算需要多少输入的 token
     function quoteExactOutput(
         QuoteExactOutputParams memory params
-    ) external view override returns (uint256 amountIn) {}
+    ) external view override returns (uint256 amountIn) {
+        uint256 amountOut = params.amountOut;
+
+        for (uint256 i = params.indexPath.length; i > 0; i--) {
+            address _pool = poolManager.getPool(
+                params.tokenIn,
+                params.tokenOut,
+                params.indexPath[i - 1]
+            );
+            IPool pool = IPool(_pool);
+
+            (uint256 amount0In, uint256 amount1In) = pool.getAmountsIn(
+                amountOut
+            );
+            amountIn = params.tokenIn < params.tokenOut ? amount0In : amount1In;
+
+            amountOut = amountIn; // 为下一次循环准备
+        }
+    }
 
     function swapCallback(
         uint256 amount0In,
         uint256 amount1In,
         bytes calldata data
     ) external override {
-        // 每次 swap 后 pool 会调用这个方法
-        // 最后一次 swap 完成后这里统一把钱打给用户
+        (address sender, address tokenIn, address tokenOut) = abi.decode(
+            data,
+            (address, address, address)
+        );
+        uint256 amountIn = tokenIn < tokenOut ? amount0In : amount1In;
+        require(
+            IERC20(tokenIn).transferFrom(sender, msg.sender, amountIn),
+            "Transfer failed"
+        );
     }
 }

--- a/demo-contract/contracts/wtfswap/SwapRouter.sol
+++ b/demo-contract/contracts/wtfswap/SwapRouter.sol
@@ -215,14 +215,16 @@ contract SwapRouter is ISwapRouter {
 
         bool zeroForOne = tokenIn < tokenOut;
         if (amount0Delta > 0) {
-            IERC20(zeroForOne ? tokenIn : tokenOut).transfer(
+            IERC20(zeroForOne ? tokenIn : tokenOut).transferFrom(
                 payer,
+                _pool,
                 uint(amount0Delta)
             );
         }
         if (amount1Delta > 0) {
-            IERC20(zeroForOne ? tokenOut : tokenIn).transfer(
+            IERC20(zeroForOne ? tokenOut : tokenIn).transferFrom(
                 payer,
+                _pool,
                 uint(amount1Delta)
             );
         }

--- a/demo-contract/contracts/wtfswap/SwapRouter.sol
+++ b/demo-contract/contracts/wtfswap/SwapRouter.sol
@@ -53,8 +53,8 @@ contract SwapRouter is ISwapRouter {
             );
 
             // 更新 amountIn 和 amountOut
-            amountIn = uint256(zeroForOne ? amount0 : amount1);
-            amountOut += uint256(zeroForOne ? amount1 : amount0);
+            amountIn = uint256(zeroForOne ? -amount0 : -amount1);
+            amountOut += uint256(zeroForOne ? -amount1 : -amount0);
 
             // 如果 amountIn 为 0，表示交换完成，跳出循环
             if (amountIn == 0) {
@@ -68,8 +68,8 @@ contract SwapRouter is ISwapRouter {
         // 发射 Swap 事件
         emit Swap(msg.sender, zeroForOne, params.amountIn, amountIn, amountOut);
 
-        // 返回 amountIn
-        return amountIn;
+        // 返回 amountOut
+        return amountOut;
     }
 
     function exactOutput(
@@ -112,8 +112,8 @@ contract SwapRouter is ISwapRouter {
             );
 
             // 更新 amountOut 和 amountIn
-            amountOut = uint256(zeroForOne ? amount1 : amount0);
-            amountIn += uint256(zeroForOne ? amount0 : amount1);
+            amountOut = uint256(zeroForOne ? -amount1 : -amount0);
+            amountIn += uint256(zeroForOne ? -amount0 : -amount1);
 
             // 如果 amountOut 为 0，表示交换完成，跳出循环
             if (amountOut == 0) {

--- a/demo-contract/contracts/wtfswap/interfaces/ISwapRouter.sol
+++ b/demo-contract/contracts/wtfswap/interfaces/ISwapRouter.sol
@@ -3,6 +3,14 @@ pragma solidity ^0.8.24;
 pragma abicoder v2;
 
 interface ISwapRouter {
+    event Swap(
+        address indexed sender,
+        bool zeroForOne,
+        uint256 amountIn,
+        uint256 amountInRemaining,
+        uint256 amountOut
+    );
+
     struct ExactInputParams {
         address tokenIn;
         address tokenOut;
@@ -56,10 +64,4 @@ interface ISwapRouter {
     function quoteExactOutput(
         QuoteExactOutputParams memory params
     ) external returns (uint256 amountIn);
-
-    function swapCallback(
-        uint256 amount0In,
-        uint256 amount1In,
-        bytes calldata data
-    ) external;
 }

--- a/demo-contract/contracts/wtfswap/interfaces/ISwapRouter.sol
+++ b/demo-contract/contracts/wtfswap/interfaces/ISwapRouter.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.24;
 pragma abicoder v2;
 
-interface ISwapRouter {
+import "./IPool.sol";
+
+interface ISwapRouter is ISwapCallback {
     event Swap(
         address indexed sender,
         bool zeroForOne,
@@ -50,18 +52,18 @@ interface ISwapRouter {
     }
 
     function quoteExactInput(
-        QuoteExactInputParams memory params
+        QuoteExactInputParams calldata params
     ) external returns (uint256 amountOut);
 
     struct QuoteExactOutputParams {
         address tokenIn;
         address tokenOut;
         uint32[] indexPath;
-        uint256 amount;
+        uint256 amountOut;
         uint160 sqrtPriceLimitX96;
     }
 
     function quoteExactOutput(
-        QuoteExactOutputParams memory params
+        QuoteExactOutputParams calldata params
     ) external returns (uint256 amountIn);
 }

--- a/demo-contract/test/wtfswap/SwapRouter.ts
+++ b/demo-contract/test/wtfswap/SwapRouter.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import { viem } from 'hardhat';
+import { Contract, Signer } from 'ethers';
+import { encodeSqrtRatioX96, TickMath } from '@uniswap/v3-sdk';
+
+describe('SwapRouter', function () {
+  async function deployFixture() {
+    // 部署两个测试代币
+    const tokenA = await viem.deployContract('TestToken');
+    const tokenB = await viem.deployContract('TestToken');
+
+    // 部署一个 PoolManager 合约
+    const poolManager = await viem.deployContract('PoolManager');
+
+    // 初始化池子的价格上下限
+    const tickLower = TickMath.getTickAtSqrtRatio(encodeSqrtRatioX96(1, 1));
+    const tickUpper = TickMath.getTickAtSqrtRatio(encodeSqrtRatioX96(40000, 1));
+    const sqrtPriceX96 = BigInt(encodeSqrtRatioX96(10000, 1).toString());
+
+    // 建立池子，同样的 tokenA 和 tokenB，两种不同的费率
+    await poolManager.write.createAndInitializePoolIfNecessary([
+      {
+        tokenA: tokenA.address,
+        tokenB: tokenB.address,
+        tickLower: tickLower,
+        tickUpper: tickUpper,
+        fee: 3000,
+        sqrtPriceX96,
+      },
+    ]);
+
+    await poolManager.write.createAndInitializePoolIfNecessary([
+      {
+        tokenA: tokenA.address,
+        tokenB: tokenB.address,
+        tickLower: tickLower,
+        tickUpper: tickUpper,
+        fee: 10000,
+        sqrtPriceX96,
+      },
+    ]);
+
+    // 拿到 PoolManager 合约的地址，部署 SwapRouter 合约
+    const swapRouter = await viem.deployContract('SwapRouter', [
+      poolManager.address,
+    ]);
+
+    return {
+      swapRouter,
+      tokenA,
+      tokenB,
+    };
+  }
+
+  it('exactInput 测试', async function () {
+    const { swapRouter, tokenA, tokenB } = await deployFixture();
+  });
+});

--- a/demo-contract/test/wtfswap/SwapRouter.ts
+++ b/demo-contract/test/wtfswap/SwapRouter.ts
@@ -1,16 +1,16 @@
-import { expect } from 'chai';
-import { viem } from 'hardhat';
-import { Contract, Signer } from 'ethers';
-import { encodeSqrtRatioX96, TickMath } from '@uniswap/v3-sdk';
+import { expect } from "chai";
+import { viem } from "hardhat";
+import hre from "hardhat";
+import { encodeSqrtRatioX96, TickMath } from "@uniswap/v3-sdk";
 
-describe('SwapRouter', function () {
+describe("SwapRouter", function () {
   async function deployFixture() {
     // 部署两个测试代币
-    const tokenA = await viem.deployContract('TestToken');
-    const tokenB = await viem.deployContract('TestToken');
+    const tokenA = await viem.deployContract("TestToken");
+    const tokenB = await viem.deployContract("TestToken");
 
     // 部署一个 PoolManager 合约
-    const poolManager = await viem.deployContract('PoolManager');
+    const poolManager = await viem.deployContract("PoolManager");
 
     // 初始化池子的价格上下限
     const tickLower = TickMath.getTickAtSqrtRatio(encodeSqrtRatioX96(1, 1));
@@ -41,18 +41,85 @@ describe('SwapRouter', function () {
     ]);
 
     // 拿到 PoolManager 合约的地址，部署 SwapRouter 合约
-    const swapRouter = await viem.deployContract('SwapRouter', [
+    const swapRouter = await viem.deployContract("SwapRouter", [
       poolManager.address,
     ]);
+
+    // 注入流动性
+    // 部署一个 LP 测试合约
+    const testLP = await viem.deployContract("TestLP");
+    // 给 testLP 发 token
+    const initBalanceValue = 1000000000000n * 10n ** 18n;
+    await tokenA.write.mint([testLP.address, initBalanceValue]);
+    await tokenB.write.mint([testLP.address, initBalanceValue]);
+    // 给池子1注入流动性
+    // 获取池子1的地址
+    const pool1Address = await poolManager.read.getPool([
+      tokenA.address,
+      tokenB.address,
+      0,
+    ]);
+    // 给池子1注入流动性
+    await tokenA.write.approve([pool1Address, initBalanceValue]);
+    await tokenB.write.approve([pool1Address, initBalanceValue]);
+    await testLP.write.mint([
+      testLP.address,
+      50000n * 10n ** 18n,
+      pool1Address,
+      tokenA.address,
+      tokenB.address,
+    ]);
+
+    // 给池子2注入流动性
+    // 获取池子2的地址
+    const pool2Address = await poolManager.read.getPool([
+      tokenA.address,
+      tokenB.address,
+      1,
+    ]);
+    // 给池子2注入流动性
+    await tokenA.write.approve([pool2Address, initBalanceValue]);
+    await tokenB.write.approve([pool2Address, initBalanceValue]);
+    await testLP.write.mint([
+      testLP.address,
+      50000n * 10n ** 18n,
+      pool2Address,
+      tokenA.address,
+      tokenB.address,
+    ]);
+
+    const [owner] = await hre.viem.getWalletClients();
+    const [sender] = await owner.getAddresses();
 
     return {
       swapRouter,
       tokenA,
       tokenB,
+      sender,
     };
   }
 
-  it('exactInput 测试', async function () {
-    const { swapRouter, tokenA, tokenB } = await deployFixture();
+  it("exactInput", async function () {
+    const { swapRouter, tokenA, tokenB, sender } = await deployFixture();
+
+    await tokenA.write.mint([sender, 1000000000000n * 10n ** 18n]);
+    await tokenA.write.approve([swapRouter.address, 10000n * 10n ** 18n]);
+
+    await swapRouter.write.exactInput([
+      {
+        tokenIn: tokenA.address,
+        tokenOut: tokenB.address,
+        amountIn: 10n * 10n ** 18n,
+        amountOutMinimum: 0n,
+        indexPath: [0, 1],
+        sqrtPriceLimitX96: BigInt(encodeSqrtRatioX96(200, 1).toString()),
+        recipient: sender,
+        deadline: BigInt(Math.floor(Date.now() / 1000) + 1000),
+      },
+    ]);
+
+    // 检查收到的 tokenOut 数量
+    const tokenBAmount = await tokenB.read.balanceOf([sender]);
+    expect(tokenBAmount).to.equal(97760848089103280585132n); // 大概是 97760 * 10 ** 18，按照 10000 的价格
   });
 });


### PR DESCRIPTION
SwapRouter合约实现，有几个问题
1. 从实现上来看，Pool 合约的 Swap 添加了 zeroForOne 这个指向性的参数，那在 swaprouter 这一层似乎不需要处理 exactInput 和 exactOutput 的差异
2. Pool 合约目前未提供仅用于计算的方法，swapRouter 中的 quote 还无法编写